### PR TITLE
add library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let _: Package =
         ],
         products: [
           .executable(name: "VTDemo", targets: ["VTDemo"]),
+          .library(name: "VirtualTerminal", targets: ["VirtualTerminal"]),
         ],
         dependencies: [
           .package(url: "https://github.com/compnerd/swift-platform-core.git", branch: "main"),


### PR DESCRIPTION
Without it `VirtualTeminal` unreachable from other packages:
```
error: 'virtual-terminal-demo': product 'VirtualTerminal' required by package 'virtual-terminal-demo' target 'virtual-terminal-demo' not found in package 'VirtualTerminal'. Did you mean '.product(name: "VirtualTerminal", package: "virtualterminal")'?
```
