### PR TITLE
Input: correct the sequence parser

### DIFF
--- a/Sources/VirtualTerminal/Input/VTInputParser.swift
+++ b/Sources/VirtualTerminal/Input/VTInputParser.swift
@@ -302,8 +302,8 @@ extension VTInputParser {
       input = buffer
       return parse(next: &input)
 
-    case 0x38: // ';' (Parameter Separator)
-      state = .CSI(parameters: parameters + [0], intermediate: intermediate)
+    case 0x3b: // ';' (Parameter Separator)
+      state = .CSI(parameters: parameters, intermediate: intermediate)
       input = input.dropFirst()
       return parse(next: &input)
 


### PR DESCRIPTION
Correct the sequence parser to handle the parameter separator in the CSI sequence. The ASCII byte for the separator was incorrect and was adding an additional parameter (`0`).