### PR TITLE
VTDemo: adjust the terminal mode switch

### DIFF
--- a/Sources/VTDemo/VTDemo.swift
+++ b/Sources/VTDemo/VTDemo.swift
@@ -322,13 +322,11 @@ private struct VTDemo {
 
     await terminal <<< .SetMode([.DEC(.UseAlternateScreenBufferSaveCursor)])
                    <<< .ResetMode([.DEC(.TextCursorEnableMode)])
-                   <<< .EraseDisplay(.EntireDisplay)
 
     defer {
       Task.synchronously {
-        await terminal <<< .SelectGraphicRendition([.Reset])
+        await terminal <<< .ResetMode([.DEC(.UseAlternateScreenBufferSaveCursor)])
                        <<< .SetMode([.DEC(.TextCursorEnableMode)])
-                       <<< .ResetMode([.DEC(.UseAlternateScreenBufferSaveCursor)])
       }
     }
 


### PR DESCRIPTION
Tweak the alternate display mode switch. When restoring the terminal, swap the order and avoid the unnecessary clear.