### PR TITLE
VTDemo: add a signal handler for `SIGINT`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,5 +25,6 @@ let _: Package =
           ]),
           .executableTarget(name: "VTDemo", dependencies: [
             .target(name: "VirtualTerminal"),
+            .product(name: "POSIXCore", package: "swift-platform-core", condition: .when(platforms: [.macOS, .linux])),
           ]),
         ])


### PR DESCRIPTION
Use `POSIXCore`'s `SignalHandler` to installer a signal handler for `SIGINT` to ensure that we restore the terminal state on `SIGINT`.

Fixes: #8