### PR TITLE
build: bump to Swift 6.1, adopt macOS v15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 
 import PackageDescription
 
 let _: Package =
   .init(name: "VirtualTerminal",
         platforms: [
-          .macOS(.v14),
+          .macOS(.v15),
         ],
         products: [
           .executable(name: "VTDemo", targets: ["VTDemo"]),


### PR DESCRIPTION
Bump the minimum macOS version to v15 and bump to Swift 6.1 by default. This matches the expectations for swift-platform-core.