### PR TITLE
VTDemo: silence a warning (NFCI)

### DIFF
--- a/Sources/VTDemo/VTDemo.swift
+++ b/Sources/VTDemo/VTDemo.swift
@@ -17,7 +17,7 @@ extension VTBuffer {
 
 // MARK: - Scene
 
-private protocol Scene {
+private protocol Scene: SendableMetatype {
   static var name: String { get }
   static var description: String { get }
 


### PR DESCRIPTION
Conform `Scene` to `SendableMetatype` to avoid the warning:
```
Stored property 'scene' of 'Sendable'-conforming struct 'Option' has non-Sendable type 'any Scene.Type'
```