### PR TITLE
VTDemo: add a polyfill for `SendableMetatype`

### DIFF
--- a/Sources/VTDemo/VTDemo.swift
+++ b/Sources/VTDemo/VTDemo.swift
@@ -15,6 +15,11 @@ extension VTBuffer {
   }
 }
 
+#if swift(<6.2)
+private protocol SendableMetatype: ~Copyable, ~Escapable {
+}
+#endif
+
 // MARK: - Scene
 
 private protocol Scene: SendableMetatype {


### PR DESCRIPTION
This allows compatibility with Swift 6.1.