### PR TITLE
Primitives, VirtualTerminal: clean up bleeding whitespace

### DIFF
--- a/Sources/Primitives/RingBuffer.swift
+++ b/Sources/Primitives/RingBuffer.swift
@@ -43,7 +43,7 @@ package struct RingBuffer<Element> {
     } else {
       size += 1
     }
-    
+
     storage[tail] = element
     tail = _index(after: tail)
   }
@@ -125,11 +125,11 @@ extension RingBuffer: Sequence {
   package struct Iterator: IteratorProtocol {
     private let buffer: RingBuffer<Element>
     private var currentIndex: Int = 0
-    
+
     internal init(_ buffer: RingBuffer<Element>) {
       self.buffer = buffer
     }
-    
+
     package mutating func next() -> Element? {
       guard currentIndex < buffer.count else { return nil }
       let element = buffer[currentIndex]
@@ -137,7 +137,7 @@ extension RingBuffer: Sequence {
       return element
     }
   }
-  
+
   package func makeIterator() -> Iterator {
     Iterator(self)
   }
@@ -202,11 +202,11 @@ extension RingBuffer {
   package borrowing func map<U>(_ transform: (borrowing Element) throws -> U) rethrows -> [U] {
     var result: [U] = []
     result.reserveCapacity(count)
-    
+
     try forEach { element in
       result.append(try transform(element))
     }
-    
+
     return result
   }
 

--- a/Sources/VirtualTerminal/Extensions/Task+Extensions.swift
+++ b/Sources/VirtualTerminal/Extensions/Task+Extensions.swift
@@ -7,7 +7,7 @@ extension Task where Failure == Error {
   @discardableResult
   package static func synchronously(priority: TaskPriority? = nil, operation: @escaping @Sendable () async throws -> Success) throws(Failure) -> Success {
     var result: Result<Success, Failure>!
-    
+
     let semaphore = DispatchSemaphore(value: 0)
     Task<Void, Failure>(priority: priority) {
       // This task will run the operation and capture the result.
@@ -21,7 +21,7 @@ extension Task where Failure == Error {
       }
     }
     semaphore.wait()
-    
+
     return try result.get()
   }
 }
@@ -30,14 +30,14 @@ extension Task where Failure == Never {
   @discardableResult
   package static func synchronously(priority: TaskPriority? = nil, operation: @escaping @Sendable () async -> Success) -> Success {
     var result: Success!
-    
+
     let semaphore = DispatchSemaphore(value: 0)
     Task<Void, Never>(priority: priority) {
       defer { semaphore.signal() }
       result = await operation()
     }
     semaphore.wait()
-    
+
     return result
   }
 }


### PR DESCRIPTION
This cleans up some bleeding whitespace in the package.