### PR TITLE
VirtualTerminal: repair the GNU Linux build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,15 +11,21 @@ let _: Package =
           .executable(name: "VTDemo", targets: ["VTDemo"]),
           .library(name: "VirtualTerminal", targets: ["VirtualTerminal"]),
         ],
+        traits: [
+          .trait(name: "GNU", description: "GNU C Library")
+        ],
         dependencies: [
-          .package(url: "https://github.com/compnerd/swift-platform-core.git", branch: "main"),
+          .package(url: "https://github.com/compnerd/swift-platform-core.git", branch: "main",
+                   traits: [.trait(name: "GNU", condition: .when(traits: ["GNU"]))]),
         ],
         targets: [
+          .target(name: "libunistring"),
           .target(name: "Geometry"),
           .target(name: "Primitives"),
           .target(name: "VirtualTerminal", dependencies: [
             .target(name: "Geometry"),
             .target(name: "Primitives"),
+            .target(name: "libunistring", condition: .when(traits: ["GNU"])),
             .product(name: "POSIXCore", package: "swift-platform-core", condition: .when(platforms: [.macOS, .linux])),
             .product(name: "WindowsCore", package: "swift-platform-core", condition: .when(platforms: [.windows])),
           ]),

--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ targets: [
 - **Swift 6.0+**
 - **macOS 14+**, **Linux**, or **Windows 10+**
 - Terminal with basic ANSI support (any modern terminal)
+- libunistring is required for Linux GNU

--- a/Sources/VirtualTerminal/Buffer/TextMetrics.swift
+++ b/Sources/VirtualTerminal/Buffer/TextMetrics.swift
@@ -4,6 +4,9 @@
 #if os(Windows)
 import WindowsCore
 #else
+#if GNU
+import libunistring
+#endif
 import POSIXCore
 import Synchronization
 
@@ -78,6 +81,12 @@ extension UnicodeScalar {
       return isWideCharacter ? 2 : 1
     }
     return CharType & C3_FULLWIDTH == C3_FULLWIDTH ? 2 : 1
+#elseif GNU
+    // Control character or invalid - zero width    -> -1
+    // Zero-width character (combining marks, etc.) -> 0
+    // Normal width character                       -> 1
+    // Wide character (CJK, etc.)                   -> 2
+    return max(1, Int(uc_width(UInt32(value), "C.UTF-8")))
 #else
     // Control character or invalid - zero width    -> -1
     // Zero-width character (combining marks, etc.) -> 0

--- a/Sources/VirtualTerminal/Platform/POSIXTerminal.swift
+++ b/Sources/VirtualTerminal/Platform/POSIXTerminal.swift
@@ -278,7 +278,11 @@ internal final actor POSIXTerminal: VTTerminal {
   /// - Screen clearing and scrolling commands
   /// - Other VT100/ANSI control sequences
   public func write(_ string: String) {
+#if GNU
+    _ = Glibc.write(self.hOut, string, string.utf8.count)
+#else
     _ = unistd.write(self.hOut, string, string.utf8.count)
+#endif
   }
 }
 

--- a/Sources/libunistring/include/libunistring.h
+++ b/Sources/libunistring/include/libunistring.h
@@ -1,0 +1,9 @@
+/* Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org> */
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef libunistring_libunistring_h
+#define libunistring_libunistring_h
+
+#include <uniwidth.h>
+
+#endif

--- a/Sources/libunistring/include/module.modulemap
+++ b/Sources/libunistring/include/module.modulemap
@@ -1,0 +1,8 @@
+/* Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org> */
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+module libunistring [system] {
+  header "libunistring.h"
+
+  link "unistring"
+}

--- a/Sources/libunistring/libunistring.c
+++ b/Sources/libunistring/libunistring.c
@@ -1,0 +1,4 @@
+/* Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org> */
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+extern unsigned char _;


### PR DESCRIPTION
This pull request adds support for the GNU C Library (glibc) and the `libunistring` library to improve Unicode character width handling on Linux systems. The changes introduce a new trait for GNU environments, conditionally include and use `libunistring` for character width calculations, and update documentation and build configuration accordingly.

**GNU/Libunistring Integration:**

* Added a `GNU` trait to `Package.swift` and configured dependencies and targets to conditionally include `libunistring` when building on GNU systems. (`Package.swift`)
* Created new module files for `libunistring`, including header and module map for integration. (`Sources/libunistring/include/libunistring.h`, `Sources/libunistring/include/module.modulemap`, `Sources/libunistring/libunistring.c`) [[1]](diffhunk://#diff-44e0eacff977c0d05ef55450e758f41d70f7c9f7fd1906f6775cca9534bd4a11R1-R9) [[2]](diffhunk://#diff-1e3e0a6c557fdb1fe4bd4eb9e01160e132fc34cc519202d76a1de976d209d964R1-R8) [[3]](diffhunk://#diff-8d0ab914dfad9ef3888946cdc3cbd513d3c664eb794c05e3d3cf2d3c5052aeb7R1-R4)

**Unicode Width Handling:**

* Updated `TextMetrics.swift` to use `libunistring`'s `uc_width` function for accurate Unicode character width calculation when the GNU trait is active. (`Sources/VirtualTerminal/Buffer/TextMetrics.swift`) [[1]](diffhunk://#diff-614c38404e0c65a58beaa1e0c991e1b35f8bd00c5af41d5b962a2a88569bf3e5R7-R9) [[2]](diffhunk://#diff-614c38404e0c65a58beaa1e0c991e1b35f8bd00c5af41d5b962a2a88569bf3e5R84-R89)

**Platform-Specific Output:**

* Modified POSIX terminal output to use `Glibc.write` instead of `unistd.write` when running on GNU systems. (`Sources/VirtualTerminal/Platform/POSIXTerminal.swift`)

**Documentation:**

* Updated the README to note that `libunistring` is required for Linux GNU environments. (`README.md`)