### PR TITLE
Platform: use a pfn to `write` and reference `Darwin.write`

### DIFF
--- a/Sources/VirtualTerminal/Platform/POSIXTerminal.swift
+++ b/Sources/VirtualTerminal/Platform/POSIXTerminal.swift
@@ -279,10 +279,13 @@ internal final actor POSIXTerminal: VTTerminal {
   /// - Other VT100/ANSI control sequences
   public func write(_ string: String) {
 #if GNU
-    _ = Glibc.write(self.hOut, string, string.utf8.count)
+    let pfnWrite = Glibc.write
+#elseif os(macOS)
+    let pfnWrite = Darwin.write
 #else
-    _ = unistd.write(self.hOut, string, string.utf8.count)
+    let pfnWrite = unistd.write
 #endif
+    _ = pfnWrite(self.hOut, string, string.utf8.count)
   }
 }
 


### PR DESCRIPTION
The `write` method is not properly exposed through the `unistd` module on Darwin. As a result, we need to special case macOS and pull it from the `Darwin` module.